### PR TITLE
Updates for 7.8 and above

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
         auto-update-conda: true
         python-version: 3.7
     - name: Configure environment
-      shell: bash -l {0}
       run: |
         conda config --set always_yes yes
         conda install -q conda-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,4 @@ jobs:
         conda install make
     - name: Build
       run: |
-        conda build --path /test /grass-recipe/recipe/ --python=3.7
+        conda build /grass-recipe/recipe/ --python=3.7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,8 @@ jobs:
       with:
         auto-update-conda: true
         python-version: 3.7
-    - name: Configure
+    - name: Configure environment
+      shell: bash -l {0}
       run: |
         conda config --set always_yes yes
         conda install -q conda-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,14 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-18.04
-
+    name: Test build - ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+        - ubuntu-18.04
+        - macos-10.15
     steps:
     - uses: actions/checkout@v2
     - uses: goanpeca/setup-miniconda@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: goanpeca/setup-miniconda@v1
-        with:
-          auto-update-conda: true
-          python-version: 3.7
+      with:
+        auto-update-conda: true
+        python-version: 3.7
     - name: Configure
       run: |
         conda config --set always_yes yes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,4 @@ jobs:
         conda install make
     - name: Build
       run: |
-        conda build /grass-recipe/recipe/ --python=3.7
+        conda build recipe/ --python=3.7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+- push
+- pull_request
+
+jobs:
+  build:
+
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: goanpeca/setup-miniconda@v1
+        with:
+          auto-update-conda: true
+          python-version: 3.7
+    - name: Configure
+      run: |
+        conda config --set always_yes yes
+        conda install -q conda-build
+        conda config --add channels conda-forge
+        conda config --add channels csdms-stack
+        conda install make
+    - name: Build
+      run: |
+        conda build --path /test /grass-recipe/recipe/ --python=3.7

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -62,9 +62,9 @@ else
 fi
 
 ./configure $CONFIGURE_FLAGS || (tail -400 "config.log" && echo "ERROR in configure step" && exit -1)
-make -j4 GDAL_DYNAMIC= > out.txt 2>&1 || (tail -400 out.txt && echo "ERROR in make step" && exit -1)
+make -j1 GDAL_DYNAMIC= > out.txt 2>&1 || (tail -1000 out.txt && echo "ERROR in make step" && exit -1)
 # make -j4 GDAL_DYNAMIC=
-make -j4 install
+make -j1 install
 
 # for d in bin etc include lib scripts share; do
 #   cp -r dist.*/$d $PREFIX

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -61,7 +61,7 @@ else
     "
 fi
 
-./configure $CONFIGURE_FLAGS
+./configure $CONFIGURE_FLAGS || (tail -400 "config.log" && echo "ERROR in configure step" && exit -1)
 make -j4 GDAL_DYNAMIC= > out.txt 2>&1 || (tail -400 out.txt && echo "ERROR in make step" && exit -1)
 # make -j4 GDAL_DYNAMIC=
 make -j4 install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -62,7 +62,7 @@ else
 fi
 
 ./configure $CONFIGURE_FLAGS || (tail -400 "config.log" && echo "ERROR in configure step" && exit -1)
-make -j1 GDAL_DYNAMIC= > out.txt 2>&1 || (tail -1000 out.txt && echo "ERROR in make step" && exit -1)
+make -j1 GDAL_DYNAMIC= > out.txt 2>&1 || (tail -7000 out.txt && echo "ERROR in make step" && exit -1)
 # make -j4 GDAL_DYNAMIC=
 make -j1 install
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,7 @@
 #! /bin/bash
 
+set -x
+
 export PATH=$PREFIX/bin:/usr/bin:/bin:/usr/sbin:/etc:/usr/lib
 
 if [ $(uname) == Darwin ]; then

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -10,6 +10,7 @@ else
 fi
 
 CONFIGURE_FLAGS="\
+  --enable-64bit \
   --prefix=$PREFIX \
   --with-freetype \
   --with-freetype-includes=$PREFIX/include/freetype2 \
@@ -41,7 +42,6 @@ CONFIGURE_FLAGS="\
   --with-cairo-libs=$PREFIX/lib \
   --with-cairo-ldflags="-lcairo" \
   --without-readline \
-  --enable-64bit \
   --with-libs=$PREFIX/lib \
   --with-includes=$PREFIX/include \
 "

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -54,6 +54,11 @@ if [ $(uname) == Darwin ]; then
 #    --enable-macosx-app
 #    --with-opencl
 #  --with-macosx-sdk=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
+else
+  CONFIGURE_FLAGS="\
+    $CONFIGURE_FLAGS \
+    --with-opengl \
+    "
 fi
 
 ./configure $CONFIGURE_FLAGS

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -14,6 +14,7 @@ CONFIGURE_FLAGS="\
   --with-freetype \
   --with-freetype-includes=$PREFIX/include/freetype2 \
   --with-freetype-libs=$PREFIX/lib \
+  --without-opengl \
   --with-gdal=$PREFIX/bin/gdal-config \
   --with-gdal-libs=$PREFIX/lib \
   --with-proj=$PREFIX/bin/proj \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -50,10 +50,10 @@ if [ $(uname) == Darwin ]; then
   CONFIGURE_FLAGS="\
     $CONFIGURE_FLAGS \
     --with-opengl=aqua \
+    --with-macosx-sdk=$CONDA_BUILD_SYSROOT \
     "
 #    --enable-macosx-app
 #    --with-opencl
-#  --with-macosx-sdk=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
 else
   CONFIGURE_FLAGS="\
     $CONFIGURE_FLAGS \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: grass
-  version: 7.4.1
+  version: 7.8.2
 
 source:
   url: https://grass.osgeo.org/grass78/source/grass-7.8.2.tar.gz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,7 @@ requirements:
     - blas
     - giflib
     - python.app [osx]
-    - poppler ==0.87
+    - poppler ==0.84
     - proj ==6.3.1
     - geos ==3.8.1
     - krb5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,16 +25,16 @@ requirements:
     - gxx_linux-64 [linux]
     - mesalib
     - libglu [linux]
-    - python ==3.7.7
+    - python 3.7.4|3.7.7|>=3.8.2
     - setuptools
     - numpy
-    - gdal ==3.0.3
+    - gdal >=3.0.3
     - freetype
     - cairo
     - matplotlib
     - pandoc
     - wxpython
-    - sqlite ==3.31.1
+    - sqlite >=3.31.1
     - jpeg
     - libpng
     - libtiff
@@ -44,9 +44,9 @@ requirements:
     - blas
     - giflib
     - python.app [osx]
-    - poppler ==0.84
-    - proj ==6.3.1
-    - geos ==3.8.1
+    - poppler >=0.84
+    - proj >=6.3.1
+    - geos >=3.8.1
     - krb5
     - flex
     - bison

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - gcc_linux-64 [linux]
     - gxx_linux-64 [linux]
     - mesalib
-    - libglu
+    - libglu [linux]
     - python
     - setuptools
     - numpy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,7 @@ requirements:
     - blas
     - giflib
     - python.app [osx]
+    - poppler
     - proj
     - geos
     - krb5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,16 +25,16 @@ requirements:
     - gxx_linux-64 [linux]
     - mesalib
     - libglu [linux]
-    - python
+    - python ==3.7.7
     - setuptools
     - numpy
-    - gdal
+    - gdal ==3.0.3
     - freetype
     - cairo
     - matplotlib
     - pandoc
     - wxpython
-    - sqlite
+    - sqlite ==3.31.1
     - jpeg
     - libpng
     - libtiff
@@ -44,9 +44,9 @@ requirements:
     - blas
     - giflib
     - python.app [osx]
-    - poppler
-    - proj
-    - geos
+    - poppler ==0.87
+    - proj ==6.3.1
+    - geos ==3.8.1
     - krb5
     - flex
     - bison

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,9 +1,11 @@
 package:
   name: grass
-  version: 7.8.2
+  version: 7.8.3
 
 source:
-  url: https://grass.osgeo.org/grass78/source/grass-7.8.2.tar.gz
+  git_url: https://github.com/OSGeo/grass.git
+  git_rev: releasebranch_7_8
+  git_depth: 1
   patches:
     - platform.make.in.patch [osx]
     - platform.make.in-linux.patch [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,6 @@ package:
 source:
   git_url: https://github.com/OSGeo/grass.git
   git_rev: releasebranch_7_8
-  git_depth: 1
   patches:
     - platform.make.in.patch [osx]
     - platform.make.in-linux.patch [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,16 +25,16 @@ requirements:
     - gxx_linux-64 [linux]
     - mesalib
     - libglu [linux]
-    - python 3.7.4|3.7.7|>=3.8.2
+    - python 3.6.10
     - setuptools
     - numpy
-    - gdal >=3.0.3
+    - gdal
     - freetype
     - cairo
     - matplotlib
     - pandoc
     - wxpython
-    - sqlite >=3.31.1
+    - sqlite
     - jpeg
     - libpng
     - libtiff
@@ -44,16 +44,16 @@ requirements:
     - blas
     - giflib
     - python.app [osx]
-    - poppler >=0.84
-    - proj >=6.3.1
-    - geos >=3.8.1
+    - poppler
+    - proj
+    - geos
     - krb5
     - flex
     - bison
 
   run:
     - libgcc
-    - python
+    - python 3.6.10
     - setuptools
     - numpy
     - gdal

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: 7.4.1
 
 source:
-  url: https://grass.osgeo.org/grass74/source/grass-7.4.1.tar.gz
+  url: https://grass.osgeo.org/grass78/source/grass-7.8.2.tar.gz
   patches:
     - platform.make.in.patch [osx]
     - platform.make.in-linux.patch [linux]
@@ -22,15 +22,16 @@ requirements:
     - clangxx_osx-64 [osx]
     - gcc_linux-64 [linux]
     - gxx_linux-64 [linux]
+    - mesalib
+    - libglu
     - python
     - setuptools
     - numpy
-    - gdal 2.0.*
+    - gdal
     - freetype
     - cairo
     - matplotlib
     - pandoc
-    - pil
     - wxpython
     - sqlite
     - jpeg
@@ -42,21 +43,22 @@ requirements:
     - blas
     - giflib
     - python.app [osx]
-    - proj4
+    - proj
     - geos
     - krb5
+    - flex
+    - bison
 
   run:
     - libgcc
     - python
     - setuptools
     - numpy
-    - gdal 2.0.*
+    - gdal
     - freetype
     - cairo
     - matplotlib
     - pandoc
-    - pil
     - wxpython
     - sqlite
     - jpeg
@@ -68,7 +70,7 @@ requirements:
     - blas
     - giflib
     - python.app [osx]
-    - proj4
+    - proj
     - geos
     - krb5
 
@@ -86,4 +88,3 @@ about:
   home: https://grass.osgeo.org/
   license: GPLv2
   dev_url: https://grass.osgeo.org/development/
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,10 +25,10 @@ requirements:
     - gxx_linux-64 [linux]
     - mesalib
     - libglu [linux]
-    - python 3.6.10
+    - python <3.7.0
     - setuptools
     - numpy
-    - gdal
+    - gdal >2
     - freetype
     - cairo
     - matplotlib
@@ -53,10 +53,10 @@ requirements:
 
   run:
     - libgcc
-    - python 3.6.10
+    - python <3.7.0
     - setuptools
     - numpy
-    - gdal
+    - gdal >2
     - freetype
     - cairo
     - matplotlib

--- a/recipe/platform.make.in-linux.patch
+++ b/recipe/platform.make.in-linux.patch
@@ -31,8 +31,8 @@
  CAIRO_HAS_XRENDER_SURFACE = @CAIRO_HAS_XRENDER_SURFACE@
  
  #Python
--PYTHON              = python
-+PYTHON              = ${prefix}/bin/python
+-PYTHON              = python3
++PYTHON              = ${prefix}/bin/python3
  
  #regex
  REGEXINCPATH        = @REGEXINCPATH@

--- a/recipe/platform.make.in.patch
+++ b/recipe/platform.make.in.patch
@@ -31,8 +31,8 @@
  CAIRO_HAS_XRENDER_SURFACE = @CAIRO_HAS_XRENDER_SURFACE@
  
  #Python
--PYTHON              = python
-+PYTHON              = ${prefix}/bin/python
+-PYTHON              = python3
++PYTHON              = ${prefix}/bin/python3
  
  #regex
  REGEXINCPATH        = @REGEXINCPATH@


### PR DESCRIPTION
These are some minimum changes needed for 7.8 and couple fixes to in the dependencies to make them more up to date and run on Linux. On failure, the configure step shows the log file. Unfortunately and importantly, this still does not compile (but the current master doesn't either for me on Linux and on Travis on macOS).

This adds a GitHub Action build on Linux and macOS. On macOS, it configures, but the build fails in almost every directory (the output is currently truncated, so the actual error is not visible). The Linux build ends with configure error when checking GDAL:

```
$PREFIX/bin/x86_64-conda_cos6-linux-gnu-cc -o conftest -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem $PREFIX/include -fdebug-prefix-map=$SRC_DIR=/usr/local/src/conda/grass-7.8.2 -fdebug-prefix-map=$PREFIX=/usr/local/src/conda-prefix  -I$PREFIX/include -DNDEBUG -D_FORTIFY_SOURCE=2 -O2 -isystem $PREFIX/include  -I$PREFIX/include -Wl,-O2 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,--disable-new-dtags -Wl,--gc-sections -Wl,-rpath,$PREFIX/lib -Wl,-rpath-link,$PREFIX/lib -L$PREFIX/lib -Wl,--export-dynamic  -L$PREFIX/lib conftest.c  -L$PREFIX/lib -lgdal -lcrypto -L$PREFIX/lib -ltiledb -L$PREFIX/lib -lpoppler -ljson-c -L$PREFIX/lib -L$PREFIX/lib -lfreexl -L$PREFIX/lib -lgeos_c -L$PREFIX/lib -lsqlite3 -L$PREFIX/lib -lkmlbase -lkmldom -lkmlengine -lkmlxsd -lkmlregionator -L$PREFIX/lib -lexpat -L$PREFIX/lib -lxerces-c -lpthread -L$PREFIX/lib -lopenjp2 -L$PREFIX/lib -lnetcdf -lmfhdf -ldf -lhdf5_hl -lhdf5 -lrt -lpthread -lz -ldl -lm -lcurl -L$PREFIX/lib -lhdf5 -L$PREFIX/lib -lmfhdf -ldf -lgif -L$PREFIX -L$PREFIX/lib -ljpeg -L$PREFIX/lib -lgeotiff -L$PREFIX/lib -ltiff -L$PREFIX -L$PREFIX/lib -lpng -L$PREFIX -L$PREFIX/lib -lcfitsio -L$PREFIX/lib -lpq -lzstd -llzma -L$PREFIX/lib -lproj -lz -L$PREFIX -L$PREFIX/lib -lpthread -lm -lrt -ldl -L$PREFIX/lib64 -L$PREFIX/lib -ldap -ldapserver -ldapclient -L$PREFIX/lib -lcurl -L$PREFIX/lib -lxml2 -L$PREFIX/lib -lz -L$PREFIX/lib -llzma -L$PREFIX/lib -L$PREFIX/lib -licui18n -licuuc -licudata -lm -ldl -lpthread -luuid -L$PREFIX/lib -lspatialite -lpcre -L$PREFIX/lib -lcurl -L$PREFIX/lib -lxml2 -L$PREFIX/lib -lz -L$PREFIX/lib -llzma -lpthread -L$PREFIX/lib -lm -ldl -L$PREFIX/lib -lkea -L$PREFIX/lib -lhdf5 -lhdf5_hl -lhdf5_cpp 1>&5
...
$PREFIX/bin/../lib/gcc/x86_64-conda_cos6-linux-gnu/7.3.0/../../../../x86_64-conda_cos6-linux-gnu/bin/ld: warning: libcrypto.so.1.0.0, needed by $PREFIX/lib/libdap.so, not found (try using -rpath or -rpath-link)
$PREFIX/bin/../lib/gcc/x86_64-conda_cos6-linux-gnu/7.3.0/../../../../x86_64-conda_cos6-linux-gnu/bin/ld: $PREFIX/lib/libgdal.so: undefined reference to `libdap::Error::get_error_message[abi:cxx11]() const'
```
